### PR TITLE
implement distributed time check using channels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/tidwall/rtime
+
+go 1.13

--- a/rtime.go
+++ b/rtime.go
@@ -26,10 +26,8 @@ var rtime time.Time
 //    }
 //
 func Now() time.Time {
-	var mu sync.Mutex
 	res := make([]time.Time, 0, len(sites))
-	cond := sync.NewCond(&mu)
-	var timedout bool
+	results := make(chan time.Time)
 
 	// get as many dates as quickly as possible
 	client := http.Client{
@@ -45,69 +43,58 @@ func Now() time.Time {
 				tm, err := time.Parse(time.RFC1123, resp.Header.Get("Date"))
 				resp.Body.Close()
 				if err == nil {
-					mu.Lock()
-					res = append(res, tm)
-					cond.Broadcast()
-					mu.Unlock()
+					results <- tm
 				}
 			}
 		}(site)
 	}
 
-	go func() {
-		// timeout after two second
-		time.Sleep(time.Second * 2)
-		mu.Lock()
-		timedout = true
-		cond.Broadcast()
-		mu.Unlock()
-	}()
-
-	mu.Lock()
-	defer mu.Unlock()
 	for {
-		if len(res) >= 3 {
-			// We must have a minimum of three results. Find the two of three
-			// that have the least difference in time and take the smaller of
-			// the two.
-			type pair struct {
-				tm0  time.Time
-				tm1  time.Time
-				diff time.Duration
-			}
-			var list []pair
-			for i := 0; i < len(res); i++ {
-				for j := i + 1; j < len(res); j++ {
-					if i != j {
-						tm0, tm1 := res[i], res[j]
-						if tm0.After(tm1) {
-							tm0, tm1 = tm1, tm0
+		select {
+		case <-time.After(2 * time.Second):
+			return time.Time{}
+		case tm := <-results:
+			res = append(res, tm)
+
+			if len(res) >= 3 {
+				// We must have a minimum of three results. Find the two of three
+				// that have the least difference in time and take the smaller of
+				// the two.
+				type pair struct {
+					tm0  time.Time
+					tm1  time.Time
+					diff time.Duration
+				}
+				var list []pair
+				for i := 0; i < len(res); i++ {
+					for j := i + 1; j < len(res); j++ {
+						if i != j {
+							tm0, tm1 := res[i], res[j]
+							if tm0.After(tm1) {
+								tm0, tm1 = tm1, tm0
+							}
+							list = append(list, pair{tm0, tm1, tm1.Sub(tm0)})
 						}
-						list = append(list, pair{tm0, tm1, tm1.Sub(tm0)})
 					}
 				}
-			}
-			sort.Slice(list, func(i, j int) bool {
-				if list[i].diff < list[j].diff {
-					return true
+				sort.Slice(list, func(i, j int) bool {
+					if list[i].diff < list[j].diff {
+						return true
+					}
+					if list[i].diff > list[j].diff {
+						return false
+					}
+					return list[i].tm0.Before(list[j].tm0)
+				})
+				res := list[0].tm0.Local()
+				// Ensure that the new time is after the previous time.
+				rmu.Lock()
+				defer rmu.Unlock()
+				if res.After(rtime) {
+					rtime = res
 				}
-				if list[i].diff > list[j].diff {
-					return false
-				}
-				return list[i].tm0.Before(list[j].tm0)
-			})
-			res := list[0].tm0.Local()
-			// Ensure that the new time is after the previous time.
-			rmu.Lock()
-			defer rmu.Unlock()
-			if res.After(rtime) {
-				rtime = res
+				return rtime
 			}
-			return rtime
 		}
-		if timedout {
-			return time.Time{}
-		}
-		cond.Wait()
 	}
 }

--- a/rtime.go
+++ b/rtime.go
@@ -27,7 +27,7 @@ var rtime time.Time
 //
 func Now() time.Time {
 	res := make([]time.Time, 0, len(sites))
-	results := make(chan time.Time)
+	results := make(chan time.Time, len(sites))
 
 	// get as many dates as quickly as possible
 	client := http.Client{


### PR DESCRIPTION
Unfortunately the new indentation of the date comparison & sorting added that code to the diff. There's nothing changed there. 

Also, I like that the API matches `time.Now` from stdlib, but truthfully would prefer it to return `(time.Time, error)`. Someone is going to use this and miss the zero-value check and then 😢.

Really not sure about perf here, but there have been a few places where swapping the cond pattern for channel sync squeezes out a bit of speed. Then again, it's only run `len(sites)` times, so...

Neat idea though -- makes me wonder where other public web results are reconciled for consensus